### PR TITLE
conda-build-makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ all: $(program_NAME)
 
 $(program_NAME): $(program_OBJS)
 	echo "LINK: $(LINK.cc) "
-	$(LINK.cc) $(program_OBJS) -o $(program_NAME) $(LDLIBS) -static
+	$(LINK.cc) $(program_OBJS) -o $(program_NAME)  $(LDLIBS) 
 
 
 clean:


### PR DESCRIPTION
fixes 
```
12:33:28 BIOCONDA INFO (OUT) collect2: error: ld returned 1 exit status
12:33:28 BIOCONDA INFO (OUT) make: *** [Makefile:25: rtk2] Error 1
...
12:33:28 BIOCONDA INFO (OUT)     return _func_defaulting_env_to_os_environ("call", *popenargs, **kwargs)
12:33:28 BIOCONDA INFO (OUT)   File "/opt/conda/lib/python3.9/site-packages/conda_build/utils.py", line 427, in _func_defaulting_env_to_os_environ
12:33:28 BIOCONDA INFO (OUT)     raise subprocess.CalledProcessError(proc.returncode, _args)
12:33:28 BIOCONDA INFO (OUT) subprocess.CalledProcessError: Command '['/bin/bash', '-o', 'errexit', '/opt/conda/conda-bld/rtk2_1713961763410/work/conda_build.sh']' returned non-zero exit status 2.
.12:33:37 BIOCONDA ERROR COMMAND FAILED (exited with 1): docker run -t --net host --rm -v /tmp/tmpd5s_mfsx/build_script.bash:/opt/build_script.bash -v /opt/mambaforge/envs/bioconda/conda-bld/:/opt/host-conda-bld -v /home/vsts/work/1/s/recipes/rtk2:/opt/recipe -e LANG=C.UTF-8 -e HOST_USER_ID=1001 quay.io/bioconda/bioconda-utils-build-env-cos7:2.14.0 /bin/bash /opt/build_script.bash
```